### PR TITLE
setup.py: List pip as a dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     author='Dustin Ingram',
     author_email='di@di.codes',
     description='The official unofficial pip API',
-    install_requires=['packaging'],
+    install_requires=['packaging', 'pip'],
     long_description=long_description,
     long_description_content_type='text/markdown',
     name='pip-api',


### PR DESCRIPTION
This is needed for especially Python 2.7 before pip was packaged
by default with the standard library via `ensurepip`.

It also injects pip into the metadata of the package, to allow
other tools to understand this package better.