### PR TITLE
parse_requirements: Add include_invalid argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,14 @@ If the command you are trying to use is not compatible, `pip_api` will raise a
   > * `Distribution.location` (`string`): The location of the installed distribution
   > * `Distribution.editable` (`bool`): Whether the distribution is editable or not
 
-* `pip_api.parse_requirements(filename)`
+* `pip_api.parse_requirements(filename, options=None, include_invalid=False)`
   > Takes a path to a filename of a Requirements file. Returns a mapping from package name to a [`packaging.requirements.Requirement`](https://packaging.pypa.io/en/latest/requirements/#packaging.requirements.Requirement) object with the following attributes:
   > * `Requirement.name` (`string`): The name of the requirement.
   > * `Requirement.extras` (`set`): A set of extras that the requirement specifies.
   > * `Requirement.specifier` ([`packaging.specifiers.SpecifierSet`](https://packaging.pypa.io/en/latest/specifiers/#packaging.specifiers.SpecifierSet)): A `SpecifierSet` of the version specified by the requirement.
   > * `Requirement.marker` ([`packaging.markers.Marker`](https://packaging.pypa.io/en/latest/markers/#packaging.markers.Marker)): A `Marker` of the marker for the requirement. Can be None.`
+  > Optionally takes an `options` parameter to override the regex used to skip requirements lines.
+  > Optionally takes an `include_invalid` parameter to return an `UnparsedRequirement` in the event that a requirement cannot be parsed correctly.
 
 ### Available with `pip>=8.0.0`:
 * `pip_api.hash(filename, algorithm='sha256')`

--- a/tests/test_parse_requirements.py
+++ b/tests/test_parse_requirements.py
@@ -59,55 +59,43 @@ PEP508_PIP_EXAMPLE_URL = (
 )
 
 
-def test_parse_requirements_PEP508_with_spaces(monkeypatch):
-    files = {
-        'a.txt': [
-            'pip @ {url}\n'.format(url=PEP508_PIP_EXAMPLE_URL),
-        ],
-        'b.txt': [
-            'pip==1.3.1 @ {url}\n'.format(url=PEP508_PIP_EXAMPLE_URL),
-        ],
-    }
-    monkeypatch.setattr(pip_api._parse_requirements, '_read_file', files.get)
+@pytest.mark.parametrize(
+    "line, result_set, url, string, spec",
+    [
+        ("pip @ {url}\n".format(url=PEP508_PIP_EXAMPLE_URL), {"pip"}, None, "pip", ""),
+        (
+            "pip==1.3.1 @ {url}\n".format(url=PEP508_PIP_EXAMPLE_URL),
+            {"pip"},
+            None,
+            "pip==1.3.1",
+            "==1.3.1",
+        ),
+        (
+            "pip@{url}\n".format(url=PEP508_PIP_EXAMPLE_URL),
+            {"pip"},
+            PEP508_PIP_EXAMPLE_URL,
+            "pip@ " + PEP508_PIP_EXAMPLE_URL,  # Note extra space after @
+            "",
+        ),
+        (
+            "pip==1.3.1@{url}\n".format(url=PEP508_PIP_EXAMPLE_URL),
+            {"pip"},
+            None,
+            "pip==1.3.1@" + PEP508_PIP_EXAMPLE_URL,  # Note no extra space after @
+            "==1.3.1@" + PEP508_PIP_EXAMPLE_URL,
+        ),
+    ],
+)
+def test_parse_requirements_PEP508(monkeypatch, line, result_set, url, string, spec):
+    files = {"a.txt": [line]}
+    monkeypatch.setattr(pip_api._parse_requirements, "_read_file", files.get)
 
-    result = pip_api.parse_requirements('a.txt')
+    result = pip_api.parse_requirements("a.txt")
 
-    assert set(result) == {'pip'}
-    assert result['pip'].url is None
-    assert str(result['pip']) == 'pip'
-
-    result = pip_api.parse_requirements('b.txt')
-
-    assert set(result) == {'pip'}
-    assert result['pip'].url is None
-    assert str(result['pip']) == 'pip==1.3.1'
-
-
-def test_parse_requirements_PEP508_without_spaces(monkeypatch):
-    files = {
-        'a.txt': [
-            'pip@{url}\n'.format(url=PEP508_PIP_EXAMPLE_URL),
-        ],
-        'b.txt': [
-            'pip==1.3.1@{url}\n'.format(url=PEP508_PIP_EXAMPLE_URL),
-        ],
-    }
-    monkeypatch.setattr(pip_api._parse_requirements, '_read_file', files.get)
-
-    result = pip_api.parse_requirements('a.txt')
-
-    assert set(result) == {'pip'}
-    assert str(result['pip'].url) == PEP508_PIP_EXAMPLE_URL
-    # Note extra space after @
-    assert str(result['pip']) == 'pip@ ' + PEP508_PIP_EXAMPLE_URL
-
-    result = pip_api.parse_requirements('b.txt')
-
-    assert set(result) == {'pip'}
-    assert result['pip'].url is None
-    # Note no extra space after @
-    assert str(result['pip']) == 'pip==1.3.1@' + PEP508_PIP_EXAMPLE_URL
-    assert result['pip'].specifier == '==1.3.1@' + PEP508_PIP_EXAMPLE_URL
+    assert set(result) == result_set
+    assert result["pip"].url == url
+    assert str(result["pip"]) == string
+    assert result["pip"].specifier == spec
 
 
 def test_parse_requirements_vcs(monkeypatch):


### PR DESCRIPTION
Rather than fail on the first invalid requirement,
allow caller to require parser continues and
includes invalid requirements in the results.