### PR TITLE
Improve parse_requirements() robustness

### DIFF
--- a/pip_api/_parse_requirements.py
+++ b/pip_api/_parse_requirements.py
@@ -20,6 +20,10 @@ parser = argparse.ArgumentParser()
 parser.add_argument("req", nargs="?")
 parser.add_argument("-r", "--requirements")
 parser.add_argument("-e", "--editable")
+# Consume index url params to avoid trying to treat them as packages.
+parser.add_argument("-i", "--index-url")
+parser.add_argument("--extra-index-url")
+parser.add_argument("-f", "--find-links")
 
 operators = packaging.specifiers.Specifier._operators.keys()
 

--- a/tests/test_parse_requirements.py
+++ b/tests/test_parse_requirements.py
@@ -32,6 +32,24 @@ def test_parse_requirements_with_comments(monkeypatch):
     assert str(result['foo']) == 'foo==1.2.3'
 
 
+@pytest.mark.parametrize(
+    'flag', ['-i', '--index-url', '--extra-index-url', '-f', '--find-links']
+)
+def test_parse_requirements_with_index_url(monkeypatch, flag):
+    files = {
+        'a.txt': [
+            '{} https://example.com/pypi/simple\n'.format(flag),
+            'foo==1.2.3\n',
+        ],
+    }
+    monkeypatch.setattr(pip_api._parse_requirements, '_read_file', files.get)
+
+    result = pip_api.parse_requirements('a.txt')
+
+    assert set(result) == {'foo'}
+    assert str(result['foo']) == 'foo==1.2.3'
+
+
 @pytest.mark.parametrize('flag', ['-r', '--requirements'])
 def test_parse_requirements_recursive(monkeypatch, flag):
     files = {

--- a/tests/test_parse_requirements.py
+++ b/tests/test_parse_requirements.py
@@ -118,3 +118,19 @@ def test_parse_requirements_editable(monkeypatch):
     assert set(result) == {'django', 'deal'}
     assert str(result['django']) == 'Django==1.11'
     assert str(result['deal']) == 'deal@ git+https://github.com/foo/deal.git#egg=deal'
+
+
+def test_parse_requirements_editable_file(monkeypatch):
+    files = {
+        'a.txt': [
+            "Django==1.11\n"
+            "-e .\n"
+        ],
+    }
+    monkeypatch.setattr(pip_api._parse_requirements, '_read_file', files.get)
+
+    result = pip_api.parse_requirements('a.txt')
+
+    assert set(result) == {'django', 'pip-api'}
+    assert str(result['django']) == 'Django==1.11'
+    assert str(result['pip-api']).startswith('pip-api@ file:///')


### PR DESCRIPTION
- Parse local package name from setup.py
    
    Currently, if a requirements.txt entry is an editable directory,
    _parse_editable returns a value which is unusable by parse_requirements,
    resulting in a TypeError.  This commit updates the code to parse out the
    package name from setup.py and return the same output format as an
    editable url.

- Ignore index url parameters in parse_requirements
    
    Currently, parse_requirements errors out when encountering a line
    which changes the index url.  Since this line is not a package, but
    instead an extra repository pip can fetch from, consume the flag and its
    parameter without attempting to parse them.
