### PR TITLE
Version 0.0.9

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,10 @@
+0.0.9
+----------------------------------------------
+
+- Test against pip 19.0 to 19.1.1 (#27)
+- Add include_invalid argument to parse_requirements (#9)
+- Vendor dependencies to avoid conflicts (#30, #31)
+
 0.0.8
 ----------------------------------------------
 

--- a/setup.py
+++ b/setup.py
@@ -24,5 +24,5 @@ setup(
     python_requires=">=2.7,!=3.0,!=3.1,!=3.2,!=3.3",
     url="http://github.com/di/pip-api",
     summary="An unofficial, importable pip API",
-    version="0.0.8",
+    version="0.0.9",
 )


### PR DESCRIPTION
- Test against pip 19.0 to 19.1.1 (#27)
- Add include_invalid argument to parse_requirements (#9)
- Vendor dependencies to avoid conflicts (#30, #31)
