### PR TITLE
Add full path to file when adding to `parsed` set

### DIFF
--- a/pip_api/_parse_requirements.py
+++ b/pip_api/_parse_requirements.py
@@ -204,8 +204,9 @@ def parse_requirements(filename, options=None, include_invalid=False):
                             raise
 
             elif known.requirements:
-                if known.requirements not in parsed:
-                    to_parse.add(os.path.join(dirname, known.requirements))
+                full_path = os.path.join(dirname, known.requirements)
+                if full_path not in parsed:
+                    to_parse.add(full_path)
             elif known.editable:
                 name, url = _parse_editable(known.editable)
                 req = requirements.Requirement("%s @ %s" % (name, url))

--- a/tests/test_parse_requirements.py
+++ b/tests/test_parse_requirements.py
@@ -179,8 +179,12 @@ def test_parse_requirements_editable_file(monkeypatch):
 
 
 def test_parse_requirements_with_relative_references(monkeypatch):
-    files = {"reqs/a.txt": ["-r b.txt\n"], "reqs/b.txt": ["django==1.11\n"]}
+    files = {
+        "reqs/base.txt": ["django==1.11\n"],
+        "reqs/test.txt": ["-r base.txt\n"],
+        "reqs/dev.txt": ["-r base.txt\n" "-r test.txt\n"],
+    }
     monkeypatch.setattr(pip_api._parse_requirements, "_read_file", files.get)
 
-    result = pip_api.parse_requirements("reqs/a.txt")
+    result = pip_api.parse_requirements("reqs/dev.txt")
     assert set(result) == {"django"}


### PR DESCRIPTION
Fixes #39 

Which is a bug caused by #37, which I wrote.  ><

I was adding the filename correctly to `to_parse`, but was not calculating the full path when checking if a file already belonged to `parsed`.  