### PR TITLE
Fix #68 keep user's env variables

### DIFF
--- a/pip_api/_call.py
+++ b/pip_api/_call.py
@@ -5,7 +5,8 @@ import sys
 
 def call(*args, cwd=None):
     python_location = os.environ.get("PIPAPI_PYTHON_LOCATION", sys.executable)
+    env = {**os.environ, **{"PIP_YES": "true"}}
     result = subprocess.check_output(
-        [python_location, "-m", "pip"] + list(args), cwd=cwd, env={"PIP_YES": "true"}
+        [python_location, "-m", "pip"] + list(args), cwd=cwd, env=env
     )
     return result.decode()


### PR DESCRIPTION
Fix #68 

Only selectively override the `PIP_YES` variable in `_call`. Critical fix for Windows users who need `%SYSTEMROOT%`