### PR TITLE
README: fix a small formatting typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ If the command you are trying to use is not compatible, `pip_api` will raise a
   > * `Requirement.name` (`string`): The name of the requirement.
   > * `Requirement.extras` (`set`): A set of extras that the requirement specifies.
   > * `Requirement.specifier` ([`packaging.specifiers.SpecifierSet`](https://packaging.pypa.io/en/latest/specifiers/#packaging.specifiers.SpecifierSet)): A `SpecifierSet` of the version specified by the requirement.
-  > * `Requirement.marker` ([`packaging.markers.Marker`](https://packaging.pypa.io/en/latest/markers/#packaging.markers.Marker)): A `Marker` of the marker for the requirement. Can be None.`
+  > * `Requirement.marker` ([`packaging.markers.Marker`](https://packaging.pypa.io/en/latest/markers/#packaging.markers.Marker)): A `Marker` of the marker for the requirement. Can be `None`.
   > Optionally takes an `options` parameter to override the regex used to skip requirements lines.
   > Optionally takes an `include_invalid` parameter to return an `UnparsedRequirement` in the event that a requirement cannot be parsed correctly.
 


### PR DESCRIPTION
Fixes a small Markdown typo that I noticed while reading.