### PR TITLE
pip_api: type hints

### DIFF
--- a/pip_api/__init__.py
+++ b/pip_api/__init__.py
@@ -5,7 +5,7 @@ from pip_api._vendor.packaging import version as packaging_version
 # Import this now because we need it below
 from pip_api._version import version
 
-PIP_VERSION = packaging_version.parse(version())
+PIP_VERSION: str = packaging_version.parse(version())
 PYTHON_VERSION = sys.version_info
 
 # Import these because they depend on the above

--- a/pip_api/__init__.py
+++ b/pip_api/__init__.py
@@ -1,11 +1,12 @@
 import sys
 
 from pip_api._vendor.packaging import version as packaging_version
+from pip_api._vendor.packaging.version import Version
 
 # Import this now because we need it below
 from pip_api._version import version
 
-PIP_VERSION: str = packaging_version.parse(version())
+PIP_VERSION: Version = packaging_version.parse(version())  # type: ignore
 PYTHON_VERSION = sys.version_info
 
 # Import these because they depend on the above

--- a/pip_api/_hash.py
+++ b/pip_api/_hash.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING
+import os
 
 from pip_api._vendor.packaging.version import Version
 
@@ -6,13 +6,10 @@ import pip_api
 from pip_api._call import call
 from pip_api.exceptions import Incompatible, InvalidArguments
 
-if TYPE_CHECKING:
-    from os import PathLike
-
 incompatible = pip_api.PIP_VERSION < Version("8.0.0")
 
 
-def hash(filename: PathLike, algorithm: str = "sha256") -> str:
+def hash(filename: os.PathLike, algorithm: str = "sha256") -> str:
     """
     Hash the given filename. Unavailable in `pip<8.0.0`
     """

--- a/pip_api/_hash.py
+++ b/pip_api/_hash.py
@@ -1,13 +1,18 @@
+from typing import TYPE_CHECKING
+
 from pip_api._vendor.packaging.version import Version
 
 import pip_api
 from pip_api._call import call
 from pip_api.exceptions import Incompatible, InvalidArguments
 
+if TYPE_CHECKING:
+    from os import PathLike
+
 incompatible = pip_api.PIP_VERSION < Version("8.0.0")
 
 
-def hash(filename, algorithm="sha256"):
+def hash(filename: PathLike, algorithm: str = "sha256") -> str:
     """
     Hash the given filename. Unavailable in `pip<8.0.0`
     """

--- a/pip_api/_hash.py
+++ b/pip_api/_hash.py
@@ -1,6 +1,6 @@
 import os
 
-from pip_api._vendor.packaging.version import Version
+from pip_api._vendor.packaging.version import Version  # type: ignore
 
 import pip_api
 from pip_api._call import call

--- a/pip_api/_installed_distributions.py
+++ b/pip_api/_installed_distributions.py
@@ -1,5 +1,6 @@
 import json
 import re
+from typing import Dict, Optional
 
 import pip_api
 from pip_api._call import call
@@ -8,7 +9,7 @@ from pip_api._vendor.packaging.version import parse
 
 
 class Distribution:
-    def __init__(self, name, version, location=None):
+    def __init__(self, name: str, version: str, location: Optional[str] = None):
         self.name = name
         self.version = parse(version)
         self.location = location
@@ -70,7 +71,7 @@ def _new_installed_distributions():
     return ret
 
 
-def installed_distributions():
+def installed_distributions() -> Dict[str, Distribution]:
     if pip_api.PIP_VERSION < parse("9.0.0"):
         return _old_installed_distributions()
     return _new_installed_distributions()

--- a/pip_api/_installed_distributions.py
+++ b/pip_api/_installed_distributions.py
@@ -5,7 +5,7 @@ from typing import Dict, Optional
 import pip_api
 from pip_api._call import call
 
-from pip_api._vendor.packaging.version import parse
+from pip_api._vendor.packaging.version import parse  # type: ignore
 
 
 class Distribution:

--- a/pip_api/_parse_requirements.py
+++ b/pip_api/_parse_requirements.py
@@ -3,7 +3,7 @@ import ast
 import os
 import re
 import traceback
-from typing import TYPE_CHECKING, Any, Dict, Optional, Union
+from typing import Any, Dict, Optional, Union
 
 from urllib.parse import urljoin
 from urllib.request import pathname2url
@@ -11,9 +11,6 @@ from urllib.request import pathname2url
 from pip_api._vendor.packaging import requirements, specifiers
 
 from pip_api.exceptions import PipError
-
-if TYPE_CHECKING:
-    from os import PathLike
 
 parser = argparse.ArgumentParser()
 parser.add_argument("req", nargs="?")
@@ -169,7 +166,7 @@ def _ignore_comments(lines_enum):
 
 
 def parse_requirements(
-    filename: PathLike, options: Optional[Any] = None, include_invalid: bool = False
+    filename: os.PathLike, options: Optional[Any] = None, include_invalid: bool = False
 ) -> Dict[str, Union[requirements.Requirement, UnparsedRequirement]]:
     to_parse = {filename}
     parsed = set()

--- a/pip_api/_parse_requirements.py
+++ b/pip_api/_parse_requirements.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, Optional, Union
 from urllib.parse import urljoin
 from urllib.request import pathname2url
 
-from pip_api._vendor.packaging import requirements, specifiers
+from pip_api._vendor.packaging import requirements, specifiers  # type: ignore
 
 from pip_api.exceptions import PipError
 
@@ -184,7 +184,7 @@ def parse_requirements(
         lines_enum = _skip_regex(lines_enum, options)
 
         for lineno, line in lines_enum:
-            req = None
+            req: Optional[Union[requirements.Requirement, UnparsedRequirement]] = None
             known, _ = parser.parse_known_args(line.strip().split())
             if known.req:
                 try:  # Try to parse this as a requirement specification
@@ -213,7 +213,7 @@ def parse_requirements(
             # If we've found a requirement, add it
             if req:
                 if not isinstance(req, UnparsedRequirement):
-                    req.comes_from = "-r {} (line {})".format(filename, lineno)
+                    req.comes_from = "-r {} (line {})".format(filename, lineno)  # type: ignore
 
                 if req.name not in name_to_req:
                     name_to_req[req.name.lower()] = req

--- a/pip_api/_parse_requirements.py
+++ b/pip_api/_parse_requirements.py
@@ -3,6 +3,7 @@ import ast
 import os
 import re
 import traceback
+from typing import TYPE_CHECKING, Any, Dict, Optional, Union
 
 from urllib.parse import urljoin
 from urllib.request import pathname2url
@@ -10,6 +11,9 @@ from urllib.request import pathname2url
 from pip_api._vendor.packaging import requirements, specifiers
 
 from pip_api.exceptions import PipError
+
+if TYPE_CHECKING:
+    from os import PathLike
 
 parser = argparse.ArgumentParser()
 parser.add_argument("req", nargs="?")
@@ -164,7 +168,9 @@ def _ignore_comments(lines_enum):
             yield line_number, line
 
 
-def parse_requirements(filename, options=None, include_invalid=False):
+def parse_requirements(
+    filename: PathLike, options: Optional[Any] = None, include_invalid: bool = False
+) -> Dict[str, Union[requirements.Requirement, UnparsedRequirement]]:
     to_parse = {filename}
     parsed = set()
     name_to_req = {}

--- a/pip_api/_vendor/packaging/_manylinux.py
+++ b/pip_api/_vendor/packaging/_manylinux.py
@@ -234,7 +234,7 @@ def _is_compatible(name: str, arch: str, version: _GLibCVersion) -> bool:
         return False
     # Check for presence of _manylinux module.
     try:
-        import _manylinux  # noqa
+        import _manylinux  # type: ignore # noqa
     except ImportError:
         return True
     if hasattr(_manylinux, "manylinux_compatible"):

--- a/pip_api/_version.py
+++ b/pip_api/_version.py
@@ -1,7 +1,7 @@
 from pip_api._call import call
 
 
-def version():
+def version() -> str:
     result = call("--version")
 
     # result is of the form:

--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,12 @@ setup(
     long_description_content_type="text/markdown",
     name="pip-api",
     packages=find_packages(),
+    package_data={
+        "pip_api": ["py.typed"],
+    },
     python_requires=">=3.6",
     url="http://github.com/di/pip-api",
     summary="An unofficial, importable pip API",
     version="0.0.20",
+    zip_safe=False,
 )

--- a/setup.py
+++ b/setup.py
@@ -28,5 +28,4 @@ setup(
     url="http://github.com/di/pip-api",
     summary="An unofficial, importable pip API",
     version="0.0.20",
-    zip_safe=False,
 )

--- a/tox.ini
+++ b/tox.ini
@@ -97,8 +97,10 @@ commands=
 [testenv:lint]
 deps=
     black
+    mypy
 commands=
     black --check .
+    mypy pip_api
 
 [pytest]
 xfail_strict=true

--- a/tox.ini
+++ b/tox.ini
@@ -97,10 +97,8 @@ commands=
 [testenv:lint]
 deps=
     black
-    mypy
 commands=
     black --check .
-    mypy pip_api
 
 [pytest]
 xfail_strict=true


### PR DESCRIPTION
I believe this covers the majority of the public API surface; will test these hints against my work in `pip-audit`.

Closes #96.