### PR TITLE
pip_api/_call: pass PIP_DISABLE_PIP_VERSION_CHECK to all invocations

### DIFF
--- a/pip_api/_call.py
+++ b/pip_api/_call.py
@@ -5,7 +5,7 @@ import sys
 
 def call(*args, cwd=None):
     python_location = os.environ.get("PIPAPI_PYTHON_LOCATION", sys.executable)
-    env = {**os.environ, **{"PIP_YES": "true"}}
+    env = {**os.environ, **{"PIP_YES": "true", "PIP_DISABLE_PIP_VERSION_CHECK": "true"}}
     result = subprocess.check_output(
         [python_location, "-m", "pip"] + list(args), cwd=cwd, env=env
     )


### PR DESCRIPTION
Downstream: https://github.com/trailofbits/pip-audit/issues/122

Apart from resolving the bug above, this has a positive effect in `pip_api`: `pip` caches its version check such that it only gets run once every couple of days. Before this change, `pip_api` would trigger the check and potentially swallow its output, causing users to miss an important warning because a dependency of theirs was using `pip` via `pip_api` internally.