### PR TITLE
Support parsing of requirement hashes

### DIFF
--- a/pip_api/__init__.py
+++ b/pip_api/__init__.py
@@ -14,4 +14,8 @@ from pip_api._hash import hash
 from pip_api._installed_distributions import installed_distributions
 
 # Import these whenever, doesn't matter
-from pip_api._parse_requirements import parse_requirements
+from pip_api._parse_requirements import (
+    parse_requirements,
+    ParsedRequirement,
+    UnparsedRequirement,
+)


### PR DESCRIPTION
Necessary for supporting `--require-hashes` in `pip-audit`.