### PR TITLE
parse_requirements: expose whether a requirement is editable

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ If the command you are trying to use is not compatible, `pip_api` will raise a
   > * `Requirement.specifier` ([`packaging.specifiers.SpecifierSet`](https://packaging.pypa.io/en/latest/specifiers/#packaging.specifiers.SpecifierSet)): A `SpecifierSet` of the version specified by the requirement.
   > * `Requirement.marker` ([`packaging.markers.Marker`](https://packaging.pypa.io/en/latest/markers/#packaging.markers.Marker)): A `Marker` of the marker for the requirement. Can be `None`.
   > * `Requirement.hashes` (`dict`): A mapping of hashes for the requirement, corresponding to `--hash=...` options.
+  > * `Requirement.editable` (`bool`): Whether the requirement is editable, corresponding to `-e ...`
   > * `Requirement.filename` (`str`): The filename that the requirement originates from.
   > * `Requirement.lineno` (`int`): The source line that the requirement was parsed from.
   >

--- a/pip_api/_parse_requirements.py
+++ b/pip_api/_parse_requirements.py
@@ -180,6 +180,7 @@ def _url_to_path(url):
 class Requirement(requirements.Requirement):
     def __init__(self, *args, **kwargs):
         self.hashes = kwargs.pop("hashes", None)
+        self.editable = kwargs.pop("editable", False)
         self.filename = kwargs.pop("filename")
         self.lineno = kwargs.pop("lineno")
 

--- a/tests/test_parse_requirements.py
+++ b/tests/test_parse_requirements.py
@@ -189,7 +189,9 @@ def test_parse_requirements_editable(monkeypatch):
 
     assert set(result) == {"django", "deal"}
     assert str(result["django"]) == "Django==1.11"
+    assert not result["django"].editable
     assert str(result["deal"]) == "deal@ git+https://github.com/foo/deal.git#egg=deal"
+    assert result["dead"].editable
 
 
 def test_parse_requirements_editable_file(monkeypatch):


### PR DESCRIPTION
See https://github.com/trailofbits/pip-audit/issues/237.