### PR TITLE
Do not treat --trusted-host as a requirement

### DIFF
--- a/pip_api/_parse_requirements.py
+++ b/pip_api/_parse_requirements.py
@@ -27,6 +27,7 @@ parser.add_argument("-i", "--index-url")
 parser.add_argument("--extra-index-url")
 parser.add_argument("-f", "--find-links")
 parser.add_argument("--hash", action="append", dest="hashes")
+parser.add_argument("--trusted-host")
 
 operators = specifiers.Specifier._operators.keys()
 

--- a/tests/test_parse_requirements.py
+++ b/tests/test_parse_requirements.py
@@ -28,7 +28,8 @@ def test_parse_requirements_with_comments(monkeypatch):
 
 
 @pytest.mark.parametrize(
-    "flag", ["-i", "--index-url", "--extra-index-url", "-f", "--find-links"]
+    "flag",
+    ["-i", "--index-url", "--extra-index-url", "-f", "--find-links", "--trusted-host"],
 )
 def test_parse_requirements_with_index_url(monkeypatch, flag):
     files = {


### PR DESCRIPTION
Prior to this commit, requirement files with a --trusted-host argument
in them were being treated as a requirement and pip-api would raise an
error due to the URL not containing an egg specifier.

This directly affect's pip-audit's ability to audit such requirement
files.

The commit fixes the issue by adding --trusted-host to the list of
known arguments that can be ignored for not being a requirement.