### PR TITLE
Add a release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,11 @@ on:
 name: release
 
 permissions:
+  # Needed to access the workflow's OIDC identity.
   id-token: write
+
+  # Needed to upload release assets.
+  contents: write
 
 jobs:
   pypi:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,3 +35,13 @@ jobs:
       uses: trailofbits/gh-action-sigstore-python@v0.0.2
       with:
         inputs: ./dist/*.tar.gz ./dist/*.whl
+
+    - name: upload artifacts to github
+      # Confusingly, this action also supports updating releases, not
+      # just creating them. This is what we want here, since we've manually
+      # created the release that triggered the action.
+      uses: softprops/action-gh-release@v1
+      with:
+        # dist/ contains the built packages, which smoketest-artifacts/
+        # contains the signatures and certificates.
+        files: dist/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,37 @@
+on:
+  release:
+    types:
+      - published
+
+name: release
+
+permissions:
+  id-token: write
+
+jobs:
+  pypi:
+    name: upload release to PyPI
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - uses: actions/setup-python@v4
+      with:
+        python-version: ">= 3.7"
+
+    - name: deps
+      run: python -m pip install -U setuptools build wheel
+
+    - name: build
+      run: python -m build
+
+    - name: publish
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_TOKEN }}
+
+    - name: sign
+      uses: trailofbits/gh-action-sigstore-python@v0.0.2
+      with:
+        inputs: ./dist/*.tar.gz ./dist/*.whl


### PR DESCRIPTION
Closes #149.

Action item for @di: needs a `PYPI_TOKEN` secret with a `pip-api` project scope.