### PR TITLE
Replace deprecated `set-output` w/ new GHA syntax

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,8 @@ jobs:
       - name: Install tox
         run: python -m pip install tox
       - id: set-matrix
-        run: echo "::set-output name=matrix::$(python generate_matrix.py)"
+        run: >-
+          echo "matrix=$(python generate_matrix.py)" >> "${GITHUB_OUTPUT}"
 
   test:
     name: ${{ matrix.toxenv }}


### PR DESCRIPTION
Refs:
* https://hynek.me/til/set-output-deprecation-github-actions/
* https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/#examples
* https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter