### PR TITLE
Make the GHA workflow runs more responsive

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,6 @@ jobs:
 
   build-matrix:
     name: Build the test matrix
-    needs: lint
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
@@ -31,7 +30,9 @@ jobs:
 
   test:
     name: ${{ matrix.toxenv }}
-    needs: build-matrix
+    needs:
+    - build-matrix
+    - lint
     runs-on: ubuntu-latest
     strategy:
       matrix: ${{ fromJson(needs.build-matrix.outputs.matrix) }}


### PR DESCRIPTION
This should make typical workflow runs report failures faster because of simultaneous runs of `lint` and matrix generation. I'd even move the dependency on `lint` to the `check` job.