### PR TITLE
Enable stale workflow runs autocancellation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,15 @@
 name: Test
 on: [push, pull_request]
+concurrency:
+  group: >-
+    ${{
+        github.workflow
+    }}-${{
+        github.ref_type
+    }}-${{
+        github.event.pull_request.number || github.sha
+    }}
+  cancel-in-progress: true
 jobs:
 
   lint:


### PR DESCRIPTION
This allows GitHub to automatically disregard GHA workflow runs for older commits.