### PR TITLE
Use sdist as a testing source in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,9 @@ concurrency:
         github.event.pull_request.number || github.sha
     }}
   cancel-in-progress: true
+env:
+  dists-artifact-name: python-package-distributions
+  sdist-artifact-name-wildcard: pip-api-*.tar.gz
 jobs:
 
   lint:
@@ -23,6 +26,36 @@ jobs:
         run: python -m pip install tox
       - name: Run linting
         run: python -m tox -e lint
+
+  build-sdist:
+    name: 📦 Build the source distribution
+    runs-on: ubuntu-latest
+    steps:
+    - name: Grab the src from GH
+      uses: actions/checkout@v3
+
+    - name: Install `pypa/build` PEP 517 front-end
+      run: python -m pip install 'build ~= 0.10.0'
+
+    - name: 📦 Build an sdist
+      run: python -m build --sdist
+
+    - name: Verify that the artifact with expected name got created
+      run: >-
+        ls -1
+        dist/${{ env.sdist-artifact-name-wildcard }}
+
+    - name: Store the distribution package
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ env.dists-artifact-name }}
+        # NOTE: Exact expected file names are specified here
+        # NOTE: as a safety measure — if anything weird ends
+        # NOTE: up being in this dir or not all dists will be
+        # NOTE: produced, this will fail the workflow.
+        path: |
+          dist/${{ env.sdist-artifact-name-wildcard }}
+        retention-days: 15
 
   build-matrix:
     name: Build the test matrix
@@ -42,12 +75,18 @@ jobs:
 
   test:
     name: ${{ matrix.toxenv }}
-    needs: build-matrix
+    needs:
+    - build-matrix
+    - build-sdist
     runs-on: ubuntu-latest
     strategy:
       matrix: ${{ fromJson(needs.build-matrix.outputs.matrix) }}
     steps:
-      - uses: actions/checkout@v3
+      - name: Retrieve the project source from an sdist inside the GHA artifact
+        uses: re-actors/checkout-python-sdist@release/v1
+        with:
+          source-tarball-name: ${{ env.sdist-artifact-name-wildcard }}
+          workflow-artifact-name: ${{ env.dists-artifact-name }}
       - name: Setup python
         uses: actions/setup-python@v4
         with:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-include *.md LICENSE
-recursive-include tests *.py
+include *.md LICENSE tox.ini
+graft tests
 global-exclude __pycache__
 global-exclude *.py[co]


### PR DESCRIPTION
Before this change, the packaging setup attempted to include the testing bits but failed to do so — some Python files are included, but they are mostly unusable.
This patch helps ensure that the test-required artifacts bundled in the published sdist are downstream-friendly by using it instead of a Git checkout in CI.