### PR TITLE
fix release workflow, corrective release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,9 +31,6 @@ jobs:
 
     - name: publish
       uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        user: __token__
-        password: ${{ secrets.PYPI_TOKEN }}
 
     - name: sign
       uses: sigstore/gh-action-sigstore-python@v2.1.1

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+0.0.33
+----------------------------------------------
+- Corrective release for 0.0.32
+
 0.0.32
 ----------------------------------------------
 - Handle editable projects with URL-sensitive characters in their paths (#208)

--- a/setup.py
+++ b/setup.py
@@ -29,5 +29,5 @@ setup(
     python_requires=">=3.7",
     url="http://github.com/di/pip-api",
     summary="An unofficial, importable pip API",
-    version="0.0.32",
+    version="0.0.33",
 )


### PR DESCRIPTION
Publish for 0.0.32 failed because the release workflow still had an explicit credential configured. 