### PR TITLE
README: remove old version availability headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,12 +87,10 @@ If the command you are trying to use is not compatible, `pip_api` will raise a
   > Optionally takes an `include_invalid` parameter to return an `UnparsedRequirement` in the event that a requirement cannot be parsed correctly.
   > Optionally takes a `strict_hashes` parameter to require that all requirements have associated hashes.
 
-### Available with `pip>=8.0.0`:
 * `pip_api.hash(filename, algorithm='sha256')`
   > Returns the resulting as a string.
   > Valid `algorithm` parameters are `'sha256'`, `'sha384'`, and `'sha512'`
 
-### Available with `pip>=19.2`:
 * `pip_api.installed_distributions(local=False, paths=[])`
   > As described above, but with an extra optional `paths` parameter to provide a list of locations to look for installed distributions. Attempting to use the `paths` parameter with `pip<19.2` will result in a `PipError`.
 

--- a/pip_api/_hash.py
+++ b/pip_api/_hash.py
@@ -1,20 +1,13 @@
 import os
 
-from pip_api._vendor.packaging.version import Version  # type: ignore
-
-import pip_api
 from pip_api._call import call
-from pip_api.exceptions import Incompatible, InvalidArguments
-
-incompatible = pip_api.PIP_VERSION < Version("8.0.0")
+from pip_api.exceptions import InvalidArguments
 
 
 def hash(filename: os.PathLike, algorithm: str = "sha256") -> str:
     """
-    Hash the given filename. Unavailable in `pip<8.0.0`
+    Hash the given filename.
     """
-    if incompatible:
-        raise Incompatible
 
     if algorithm not in ["sha256", "sha384", "sha512"]:
         raise InvalidArguments("Algorithm {} not supported".format(algorithm))

--- a/pip_api/_installed_distributions.py
+++ b/pip_api/_installed_distributions.py
@@ -40,7 +40,9 @@ class Distribution:
         )
 
 
-def _new_installed_distributions(local: bool, paths: List[os.PathLike]):
+def installed_distributions(
+    local: bool = False, paths: List[os.PathLike] = []
+) -> Dict[str, Distribution]:
     list_args = ["list", "-v", "--format=json"]
     if local:
         list_args.append("--local")
@@ -65,9 +67,3 @@ def _new_installed_distributions(local: bool, paths: List[os.PathLike]):
         ret[dist.name] = dist
 
     return ret
-
-
-def installed_distributions(
-    local: bool = False, paths: List[os.PathLike] = []
-) -> Dict[str, Distribution]:
-    return _new_installed_distributions(local, paths)

--- a/tests/test_hash.py
+++ b/tests/test_hash.py
@@ -2,12 +2,7 @@ import pytest
 
 import pip_api
 
-xfail_incompatible = pytest.mark.xfail(
-    pip_api._hash.incompatible, reason="Incompatible"
-)
 
-
-@xfail_incompatible
 @pytest.mark.parametrize(
     "algorithm, expected",
     [
@@ -28,14 +23,12 @@ def test_hash(some_distribution, algorithm, expected):
     assert result == expected
 
 
-@xfail_incompatible
 def test_hash_default_algorithm_is_256(some_distribution):
     sha256 = "cce4031ec744585688ddab649427133ac22396da29ad82fdbd11692c3a26fe19"
 
     assert pip_api.hash(some_distribution.filename) == sha256
 
 
-@xfail_incompatible
 def test_hash_invalid_algorithm():
     with pytest.raises(pip_api.exceptions.InvalidArguments):
         pip_api.hash("whatever", "invalid")

--- a/tests/test_installed_distributions.py
+++ b/tests/test_installed_distributions.py
@@ -1,13 +1,9 @@
 import os
+
 import pytest
 
 import pip_api
 from pip_api._vendor.packaging.version import parse
-from pip_api.exceptions import PipError
-
-
-PATH_SUPPORTED = pip_api.PIP_VERSION >= parse("19.2")
-PATH_UNSUPPORTED_MSG = r"pip .* does not support the `paths` argument"
 
 
 def test_installed_distributions(pip, some_distribution):
@@ -100,12 +96,8 @@ def test_installed_distributions_path(pip, some_distribution, target):
     assert some_distribution.name not in distributions
 
     # No packages installed under the target directory yet
-    if PATH_SUPPORTED:
-        distributions = pip_api.installed_distributions(paths=[target])
-        assert some_distribution.name not in distributions
-    else:
-        with pytest.raises(PipError, match=PATH_UNSUPPORTED_MSG):
-            pip_api.installed_distributions(paths=[target])
+    distributions = pip_api.installed_distributions(paths=[target])
+    assert some_distribution.name not in distributions
 
     # Install the package under the target directory
     pip.run("install", "--target", target, some_distribution.filename)
@@ -116,12 +108,8 @@ def test_installed_distributions_path(pip, some_distribution, target):
     assert some_distribution.name not in distributions
 
     # If we set the path to the target directory, we should find the installed package
-    if PATH_SUPPORTED:
-        distributions = pip_api.installed_distributions(paths=[target])
-        assert some_distribution.name in distributions
-    else:
-        with pytest.raises(PipError, match=PATH_UNSUPPORTED_MSG):
-            pip_api.installed_distributions(paths=[target])
+    distributions = pip_api.installed_distributions(paths=[target])
+    assert some_distribution.name in distributions
 
 
 def test_installed_distributions_multiple_paths(
@@ -132,13 +120,9 @@ def test_installed_distributions_multiple_paths(
     assert other_distribution.name not in distributions
 
     # No packages installed under the target directory yet
-    if PATH_SUPPORTED:
-        distributions = pip_api.installed_distributions(paths=[target, other_target])
-        assert some_distribution.name not in distributions
-        assert other_distribution.name not in distributions
-    else:
-        with pytest.raises(PipError, match=PATH_UNSUPPORTED_MSG):
-            pip_api.installed_distributions(paths=[target, other_target])
+    distributions = pip_api.installed_distributions(paths=[target, other_target])
+    assert some_distribution.name not in distributions
+    assert other_distribution.name not in distributions
 
     # Install the packages under the two target directories
     pip.run("install", "--target", target, some_distribution.filename)
@@ -151,10 +135,6 @@ def test_installed_distributions_multiple_paths(
     assert other_distribution.name not in distributions
 
     # If we set the path to the target directory, we should find the installed package
-    if PATH_SUPPORTED:
-        distributions = pip_api.installed_distributions(paths=[target, other_target])
-        assert some_distribution.name in distributions
-        assert other_distribution.name in distributions
-    else:
-        with pytest.raises(PipError, match=PATH_UNSUPPORTED_MSG):
-            pip_api.installed_distributions(paths=[target, other_target])
+    distributions = pip_api.installed_distributions(paths=[target, other_target])
+    assert some_distribution.name in distributions
+    assert other_distribution.name in distributions


### PR DESCRIPTION
Per the bump to Python 3.8 (https://github.com/di/pip-api/pull/223), these headers are now vestigial -- all supported versions of `pip` support these APIs 🙂 