### PR TITLE
tox, tests: drop virtualenv dependency

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -108,7 +108,7 @@ def venv(tmpdir, isolate):
     venv_location = os.path.join(str(tmpdir), "workspace", "venv")
     # Create the virtualenv without pip installed; we'll explicitly install it
     # in each temporary environment.
-    venv = virtualenv.create(venv_location, with_pip=False)
+    venv = virtualenv.create(venv_location, with_pip=True)
 
     os.environ["PIPAPI_PYTHON_LOCATION"] = os.path.join(venv_location, "bin", "python")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 import os
 import shutil
 import subprocess
-import venv as virtualenv
+import venv
 
 import pretend
 import pytest
@@ -99,18 +99,18 @@ def isolate(tmpdir):
 
 
 @pytest.fixture
-def venv(tmpdir, isolate):
+def temp_venv(tmpdir, isolate):
     """
     Return a virtual environment which is unique to each test function
     invocation created inside of a sub directory of the test function's
     temporary directory.
     """
     venv_location = os.path.join(str(tmpdir), "workspace", "venv")
-    venv = virtualenv.create(venv_location, with_pip=True)
+    env = venv.create(venv_location, with_pip=True)
 
     os.environ["PIPAPI_PYTHON_LOCATION"] = os.path.join(venv_location, "bin", "python")
 
-    yield venv
+    yield env
 
     del os.environ["PIPAPI_PYTHON_LOCATION"]
     shutil.rmtree(venv_location)
@@ -145,7 +145,7 @@ class PipTestEnvironment:
 
 
 @pytest.fixture()
-def pip(tmpdir, venv):
+def pip(tmpdir, temp_venv):
     """
     Return a PipTestEnvironment which is unique to each test function and
     will execute all commands inside of the unique virtual environment for this

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,14 +1,13 @@
 import os
 import shutil
 import subprocess
+import venv as virtualenv
 
-import pytest
 import pretend
-import virtualenv
-
-from pip_api._vendor.packaging.version import Version
+import pytest
 
 import pip_api
+from pip_api._vendor.packaging.version import Version
 
 
 @pytest.fixture
@@ -107,7 +106,9 @@ def venv(tmpdir, isolate):
     temporary directory.
     """
     venv_location = os.path.join(str(tmpdir), "workspace", "venv")
-    venv = virtualenv.cli_run([venv_location])
+    # Create the virtualenv without pip installed; we'll explicitly install it
+    # in each temporary environment.
+    venv = virtualenv.create(venv_location, with_pip=False)
 
     os.environ["PIPAPI_PYTHON_LOCATION"] = os.path.join(venv_location, "bin", "python")
 
@@ -135,9 +136,7 @@ def other_target(tmpdir):
 
 class PipTestEnvironment:
     def __init__(self):
-        # Install the right version of pip. By default,
-        # virtualenv gets the version from the wheels that
-        # are bundled along with it
+        # Install the right version of pip.
         self.run("install", "pip=={}".format(str(pip_api.PIP_VERSION)))
 
     def run(self, *args):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -106,8 +106,6 @@ def venv(tmpdir, isolate):
     temporary directory.
     """
     venv_location = os.path.join(str(tmpdir), "workspace", "venv")
-    # Create the virtualenv without pip installed; we'll explicitly install it
-    # in each temporary environment.
     venv = virtualenv.create(venv_location, with_pip=True)
 
     os.environ["PIPAPI_PYTHON_LOCATION"] = os.path.join(venv_location, "bin", "python")

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,6 @@ usedevelop=True
 deps=
     pretend
     pytest
-    virtualenv>20
     pip242: pip==24.2
     pip2412: pip==24.1.2
     pip2411: pip==24.1.1
@@ -80,7 +79,6 @@ install_command = pip install --pre -U {opts} {packages}
 deps=
     pretend
     pytest
-    virtualenv>20
     pip
 
 commands=


### PR DESCRIPTION
~~WIP, drafting while I make sure this works as expected.~~

This can be done using the stdlib's venv, which
should save a decent bit of CI standup time
(fewer things to install per runner).